### PR TITLE
Implement password change feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/app/authentication/verify-password-change/cover/page.js
+++ b/src/app/authentication/verify-password-change/cover/page.js
@@ -1,0 +1,29 @@
+import VerifyPasswordChangeForm from '@/components/authentication/VerifyPasswordChangeForm'
+import Image from 'next/image'
+import React from 'react'
+
+const page = () => {
+  return (
+    <main className="auth-cover-wrapper">
+      <div className="auth-cover-content-inner">
+        <div className="auth-cover-content-wrapper">
+          <div className="auth-img">
+            <Image width={600} height={600} sizes='100vw' src="/images/auth/auth-cover-reset-bg.svg" alt="img" className="img-fluid" />
+          </div>
+        </div>
+      </div>
+      <div className="auth-cover-sidebar-inner">
+        <div className="auth-cover-card-wrapper">
+          <div className="auth-cover-card p-sm-5">
+            <div className="wd-50 mb-5">
+              <img src="/images/logo-abbr.png" alt="img" className="img-fluid" />
+            </div>
+            <VerifyPasswordChangeForm />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+export default page

--- a/src/components/authentication/ResetForm.jsx
+++ b/src/components/authentication/ResetForm.jsx
@@ -1,19 +1,52 @@
+'use client'
 import Link from 'next/link'
-import React from 'react'
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { BASE_URL } from '@/utils/api'
 
 const ResetForm = ({ path }) => {
+    const [email, setEmail] = useState('')
+    const router = useRouter()
+
+    const handleSubmit = async (e) => {
+        e.preventDefault()
+        try {
+            const response = await fetch(`${BASE_URL}/auth/request-password-change`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ email })
+            })
+            const data = await response.json()
+            if (data.success) {
+                router.push('/authentication/verify-password-change/cover')
+            } else {
+                alert(data.message)
+            }
+        } catch (error) {
+            console.error('Error:', error)
+            alert('An error occurred. Please try again.')
+        }
+    }
+
     return (
         <>
-            <h2 className="fs-20 fw-bolder mb-4">Reset</h2>
-            <h4 className="fs-13 fw-bold mb-2">Reset to your username/password</h4>
-            <p className="fs-12 fw-medium text-muted">Enter your email and a reset link will sent to you, let's
-                access our the best recommendation for you.</p>
-            <form action="auth-resetting-cover.html" className="w-100 mt-4 pt-2">
+            <h2 className="fs-20 fw-bolder mb-4">Reset Password</h2>
+            <p className="fs-12 fw-medium text-muted">Enter your email to receive an OTP to reset your password.</p>
+            <form onSubmit={handleSubmit} className="w-100 mt-4 pt-2">
                 <div className="mb-4">
-                    <input className="form-control" placeholder="Email or Username" required />
+                    <input
+                        type="email"
+                        className="form-control"
+                        placeholder="Email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                    />
                 </div>
                 <div className="mt-5">
-                    <button type="submit" className="btn btn-lg btn-primary w-100">Reset Now</button>
+                    <button type="submit" className="btn btn-lg btn-primary w-100">Send OTP</button>
                 </div>
             </form>
             <div className="mt-5 text-muted">

--- a/src/components/authentication/VerifyPasswordChangeForm.jsx
+++ b/src/components/authentication/VerifyPasswordChangeForm.jsx
@@ -1,0 +1,78 @@
+'use client'
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { BASE_URL } from '@/utils/api'
+
+const VerifyPasswordChangeForm = () => {
+    const [email, setEmail] = useState('')
+    const [otp, setOtp] = useState('')
+    const [newPassword, setNewPassword] = useState('')
+    const router = useRouter()
+
+    const handleSubmit = async (e) => {
+        e.preventDefault()
+        try {
+            const response = await fetch(`${BASE_URL}/auth/verify-password-change`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ email, otp, new_password: newPassword })
+            })
+            const data = await response.json()
+            if (data.success) {
+                alert('Password changed successfully!')
+                router.push('/authentication/login/cover')
+            } else {
+                alert(data.message)
+            }
+        } catch (error) {
+            console.error('Error:', error)
+            alert('An error occurred. Please try again.')
+        }
+    }
+
+    return (
+        <>
+            <h2 className="fs-20 fw-bolder mb-4">Verify Password Change</h2>
+            <p className="fs-12 fw-medium text-muted">Enter your email, the OTP you received, and your new password.</p>
+            <form onSubmit={handleSubmit} className="w-100 mt-4 pt-2">
+                <div className="mb-4">
+                    <input
+                        type="email"
+                        className="form-control"
+                        placeholder="Email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                    />
+                </div>
+                <div className="mb-4">
+                    <input
+                        type="text"
+                        className="form-control"
+                        placeholder="OTP"
+                        required
+                        value={otp}
+                        onChange={(e) => setOtp(e.target.value)}
+                    />
+                </div>
+                <div className="mb-4">
+                    <input
+                        type="password"
+                        className="form-control"
+                        placeholder="New Password"
+                        required
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                    />
+                </div>
+                <div className="mt-5">
+                    <button type="submit" className="btn btn-lg btn-primary w-100">Change Password</button>
+                </div>
+            </form>
+        </>
+    )
+}
+
+export default VerifyPasswordChangeForm


### PR DESCRIPTION
This change adds the functionality for users to change their password. It includes:
- A form to request a password change by sending an OTP to the user's email.
- A form to verify the password change using the OTP and a new password.
- API calls to the `/auth/request-password-change` and `/auth/verify-password-change` endpoints.

The `newPassword` key in the verify API call has been changed to `new_password` as requested.